### PR TITLE
Limit nix features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,15 +1074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,7 +1118,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/zerostash-files/Cargo.toml
+++ b/zerostash-files/Cargo.toml
@@ -30,7 +30,7 @@ itertools = "0.10"
 seahash = "4.0"
 
 libc = "0.2"
-nix = "0.24"
+nix = { version = "0.24", default-features = false, features = ["fs"] }
 
 chrono = "0.4.19"
 

--- a/zerostash/Cargo.toml
+++ b/zerostash/Cargo.toml
@@ -28,7 +28,7 @@ ignore = "0.4"
 humansize = "1.1.1"
 chrono = "0.4.19"
 termcolor = "1.1"
-nix = "0.24"
+nix = { version = "0.24", default-features = false, features = ["user"] }
 
 [dependencies.abscissa_tokio]
 version = "0.6"


### PR DESCRIPTION
This removes memoffset as an indirect dependency and reduces compile times slightly.